### PR TITLE
[FEAT] #6 시간 선택 페이지 UI 설계

### DIFF
--- a/src/features/timeSetting/components/TimeSelector.js
+++ b/src/features/timeSetting/components/TimeSelector.js
@@ -65,25 +65,47 @@ export function TimeSelector({ times, selected, toggle }) {
   );
 }
 
+
+const DAY_CELL_WIDTH = 65;
+const TIME_LABEL_CELL_WIDTH = 60;
+const CELL_HEIGHT = 40;
+const DEFAULT_PADDING = 10;
+
+const HEADER_BORDER_WIDTH = 1;
+const TIME_LABEL_BORDER_WIDTH = 1;
+const CELL_BORDER_WIDTH = 0.5;
+
+const GRID_BORDER_COLOR = "#ccc";
+const CELL_BORDER_COLOR = "#eee";
+const SELECTED_CELL_BACKGROUND = "dodgerblue";
+const HEADER_FONT_WEIGHT = "bold";
+
 const styles = StyleSheet.create({
   row: { flexDirection: "row" },
   headerCell: {
-    width: 65,
-    padding: 10,
+    width: DAY_CELL_WIDTH,
+    padding: DEFAULT_PADDING,
     alignItems: "center",
     justifyContent: "center",
-    borderBottomWidth: 1,
-    borderColor: "#ccc",
+    borderBottomWidth: HEADER_BORDER_WIDTH,
+    borderColor: GRID_BORDER_COLOR,
   },
-  headerText: { fontWeight: "bold" },
+  headerText: { fontWeight: HEADER_FONT_WEIGHT },
   timeLabelCell: {
-    width: 60,
-    padding: 10,
+    width: TIME_LABEL_CELL_WIDTH,
+    padding: DEFAULT_PADDING,
     alignItems: "center",
     justifyContent: "center",
-    borderRightWidth: 1,
-    borderColor: "#ccc",
+    borderRightWidth: TIME_LABEL_BORDER_WIDTH,
+    borderColor: GRID_BORDER_COLOR,
   },
-  cell: { width: 65, height: 40, borderWidth: 0.5, borderColor: "#eee" },
-  selectedCell: { backgroundColor: "dodgerblue" },
+  cell: { 
+    width: DAY_CELL_WIDTH, 
+    height: CELL_HEIGHT, 
+    borderWidth: CELL_BORDER_WIDTH, 
+    borderColor: CELL_BORDER_COLOR 
+  },
+  selectedCell: { 
+    backgroundColor: SELECTED_CELL_BACKGROUND 
+  },
 });

--- a/src/features/timeSetting/components/TimeSelector.js
+++ b/src/features/timeSetting/components/TimeSelector.js
@@ -1,0 +1,89 @@
+import React from "react";
+import { View, Text, Pressable, StyleSheet, ScrollView } from "react-native";
+
+export function TimeSelector({ times, selected, toggle }) {
+  // 1. 데이터를 그리드에 맞게 가공
+  const { dates, timeSlots } = React.useMemo(() => {
+    if (!times || times.length === 0) {
+      return { dates: [], timeSlots: [] };
+    }
+
+    const dateSet = new Set();
+    const timeSlotSet = new Set();
+
+    times.forEach((dateTime) => {
+      const [date, time] = dateTime.split(" ");
+      dateSet.add(date);
+      timeSlotSet.add(time);
+    });
+
+    return {
+      dates: Array.from(dateSet).sort(),
+      timeSlots: Array.from(timeSlotSet).sort(),
+    };
+  }, [times]);
+
+  if (dates.length === 0) {
+    return <Text>선택 가능한 시간이 없습니다.</Text>;
+  }
+
+  // 2. 그리드 렌더링
+  return (
+    <ScrollView horizontal>
+      <View>
+        {/* 날짜 헤더 */}
+        <View style={styles.row}>
+          <View style={styles.timeLabelCell} />
+          {dates.map((date) => (
+            <View key={date} style={styles.headerCell}>
+              <Text style={styles.headerText}>{date.substring(5)}</Text>
+            </View>
+          ))}
+        </View>
+
+        {/* 시간대별 선택 셀 */}
+        {timeSlots.map((time) => (
+          <View key={time} style={styles.row}>
+            <View style={styles.timeLabelCell}>
+              <Text>{time}</Text>
+            </View>
+            {dates.map((date) => {
+              const dateTime = `${date} ${time}`;
+              const isSelected = selected.has(dateTime);
+              return (
+                <Pressable
+                  key={dateTime}
+                  onPress={() => toggle(dateTime)}
+                  style={[styles.cell, isSelected && styles.selectedCell]}
+                />
+              );
+            })}
+          </View>
+        ))}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: { flexDirection: "row" },
+  headerCell: {
+    width: 65,
+    padding: 10,
+    alignItems: "center",
+    justifyContent: "center",
+    borderBottomWidth: 1,
+    borderColor: "#ccc",
+  },
+  headerText: { fontWeight: "bold" },
+  timeLabelCell: {
+    width: 60,
+    padding: 10,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRightWidth: 1,
+    borderColor: "#ccc",
+  },
+  cell: { width: 65, height: 40, borderWidth: 0.5, borderColor: "#eee" },
+  selectedCell: { backgroundColor: "dodgerblue" },
+});

--- a/src/features/timeSetting/hooks/useTimeSetting.js
+++ b/src/features/timeSetting/hooks/useTimeSetting.js
@@ -35,8 +35,11 @@ export function useTimeSetting(roomId) {
   };
 
   // 등록하기
-  const submit = async () => {
+  const submit = async (navigation) => {
     const result = await postAvailableTimes(roomId, Array.from(selected));
+    if (result.success) {
+      navigation.navigate("Result");
+    }
     return result.success;
   };
 

--- a/src/features/timeSetting/hooks/useTimeSetting.js
+++ b/src/features/timeSetting/hooks/useTimeSetting.js
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { getRoomInfo, postAvailableTimes } from "../services/timeSettingApi";
+
+export function useTimeSetting(roomId) {
+  const [room, setRoom] = useState(null);
+  const [times, setTimes] = useState([]);
+  const [selected, setSelected] = useState(new Set());
+
+  // 방 정보 불러오기
+  useEffect(() => {
+    const fetchRoomInfo = async () => {
+      const data = await getRoomInfo(roomId);
+      
+      setRoom(data);
+
+      if (data && data.dates && data.timeSlots) {
+        const generatedTimes = data.dates.flatMap((date) =>
+          data.timeSlots.map((time) => `${date} ${time}`)
+        );
+        console.log(generatedTimes);
+        setTimes(generatedTimes);
+      }
+    };
+
+    fetchRoomInfo();
+  }, [roomId]);
+
+  // 시간 토글
+  const toggle = (t) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      next.has(t) ? next.delete(t) : next.add(t);
+      return next;
+    });
+  };
+
+  // 등록하기
+  const submit = async () => {
+    const result = await postAvailableTimes(roomId, Array.from(selected));
+    return result.success;
+  };
+
+  return { room, times, selected, toggle, submit };
+}

--- a/src/features/timeSetting/screens/TimeSettingScreen.js
+++ b/src/features/timeSetting/screens/TimeSettingScreen.js
@@ -10,11 +10,8 @@ export function TimeSettingScreen() {
   const { room, times, selected, toggle, submit } =
     useTimeSetting(roomId) || {};
 
-  const handleSubmit = async () => {
-    const ok = await submit();
-    if (ok) {
-      navigation.navigate("Result");
-    }
+  const handleSubmit = () => {
+    submit(navigation);
   };
 
   return (

--- a/src/features/timeSetting/screens/TimeSettingScreen.js
+++ b/src/features/timeSetting/screens/TimeSettingScreen.js
@@ -1,10 +1,57 @@
 import React from "react";
-import { View, Text } from "react-native";
+import { View, Text, Pressable, Alert, StyleSheet, ScrollView, } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import { useTimeSetting } from "../hooks/useTimeSetting";
+import { TimeSelector } from "../components/TimeSelector";
 
 export function TimeSettingScreen() {
+  const navigation = useNavigation();
+  const roomId = 1;
+  const { room, times, selected, toggle, submit } =
+    useTimeSetting(roomId) || {};
+
+  const handleSubmit = async () => {
+    const ok = await submit();
+    if (ok) {
+      navigation.navigate("Result");
+    }
+  };
+
   return (
-    <View>
-      <Text>시간 설정 화면입니다</Text>
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>{ room ? room.title : "방 제목" }</Text>
+        <Text style={styles.participants}>
+          {room && (
+            <Text style={styles.participants}>
+            {room.respondedCount} / {room.totalParticipants} 명 참여
+            </Text>
+          )}
+        </Text>
+      </View>
+      <View style={styles.selectorContainer}>
+        <TimeSelector times={times} selected={selected} toggle={toggle} />
+      </View>
+      <Pressable style={styles.submitButton} onPress={handleSubmit}>
+        <Text style={styles.submitButtonText}>등록하기</Text>
+      </Pressable>
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#fff" },
+  header: { padding: 20, borderBottomWidth: 1, borderColor: "#eee" },
+  title: { fontSize: 24, fontWeight: "bold" },
+  participants: { fontSize: 16, color: "gray", marginTop: 4 },
+  selectorContainer: { flex: 1 },
+  submitButton: {
+    backgroundColor: "dodgerblue",
+    padding: 15,
+    margin: 20,
+    bottom: 20,
+    borderRadius: 10,
+    alignItems: "center",
+  },
+  submitButtonText: { color: "white", fontSize: 16, fontWeight: "bold" },
+});

--- a/src/features/timeSetting/services/timeSettingApi.js
+++ b/src/features/timeSetting/services/timeSettingApi.js
@@ -1,6 +1,7 @@
 // 서버 통신 관련 (임시로 콘솔 로그로 대체)
-export const getRoomInfo = async (roomId) => {
-  console.log("GET /api/rooms/" + roomId);
+export const getRoomInfo = (roomId) => {
+  // eslint-disable-next-line no-console
+  console.log(`GET /api/rooms/${roomId}`);
   // 실제로는 fetch로 불러오면 됨
   return {
     roomId: 1,
@@ -14,7 +15,8 @@ export const getRoomInfo = async (roomId) => {
   };
 };
 
-export const postAvailableTimes = async (roomId, times) => {
-  console.log("POST /api/rooms/" + roomId, times);
+export const postAvailableTimes = (roomId, times) => {
+  // eslint-disable-next-line no-console
+  console.log(`POST /api/rooms/${roomId}`, times);
   return { success: true };
 };

--- a/src/features/timeSetting/services/timeSettingApi.js
+++ b/src/features/timeSetting/services/timeSettingApi.js
@@ -1,0 +1,20 @@
+// 서버 통신 관련 (임시로 콘솔 로그로 대체)
+export const getRoomInfo = async (roomId) => {
+  console.log("GET /api/rooms/" + roomId);
+  // 실제로는 fetch로 불러오면 됨
+  return {
+    roomId: 1,
+    title: "스터디 모임",
+    dates: ["2025-10-15", "2025-10-17", "2025-10-20", "2025-10-21"],
+    timeSlots: ["09:00", "13:00", "14:00", "15:00", "16:00", "17:00", "18:00", "19:00"],
+    isOwner: false,
+    hasResponded: false,
+    totalParticipants: 5,
+    respondedCount: 3,
+  };
+};
+
+export const postAvailableTimes = async (roomId, times) => {
+  console.log("POST /api/rooms/" + roomId, times);
+  return { success: true };
+};


### PR DESCRIPTION
## 📋 변경 사항

<!-- 어떤 변경사항이 있는지 간단히 설명해주세요 -->
- 시간 선택 화면 기본 구현
- 방 정보 데이터 더미 API 연결
- 날짜/시간 기반 시간표 UI
## 🔗 관련 이슈

Closes #6 

## 📝 작업 내용

- useTimeSetting 훅 생성 및 방 정보 불러오기
- TimeSelector 컴포넌트로 날짜/시간 표 UI 구현
- TimeSettingScreen 구성 및 “등록하기” 버튼 기능 구현
- postAvailableTimes() 호출 시 선택 시간 서버 전송 테스트, console.log()로 대체
- 등록 성공 시 Result 화면으로 이동

## 📸 스크린샷 (UI 변경 시)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-17 at 13 44 51" src="https://github.com/user-attachments/assets/76ce72e5-69b1-4845-bd5c-d10e1b9d9bcb" />

## 🔍 리뷰 포인트 (선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 적어주세요 -->
- useTimeSetting의 상태 관리 구조가 적절한지
- API 호출부를 실제 서버로 교체 시 구조 변경 필요 여부