### PR TITLE
[FEAT] #13 결과 페이지 UI 설계 및 데이터 구조 정리

### DIFF
--- a/src/data/mockData.js
+++ b/src/data/mockData.js
@@ -63,3 +63,100 @@ export const mockRooms = [
     ],
   },
 ];
+
+export const mockRoomConfig = {
+  roomId: 1,
+  title: "스터디 모임",
+  dates: ["2025-10-15", "2025-10-17", "2025-10-20", "2025-10-22", "2025-10-30"],
+  timeSlots: ["09:00", "13:00", "14:00", "15:00", "16:00", "17:00", "18:00", "19:00"],
+  isOwner: false,
+  hasResponded: false,
+  totalParticipants: 5,
+  respondedCount: 3,
+};
+
+export const mockResultData = {
+  message: "응답이 저장되었습니다",
+  roomInfo: {
+    ...mockRoomConfig, // title, totalParticipants, respondedCount 등 포함
+  },
+  allParticipants: [
+    { id: 1, nickname: "김철수" },
+    { id: 2, nickname: "이영희" },
+    { id: 3, nickname: "최지우" },
+    { id: 4, nickname: "정수진" },
+    { id: 5, nickname: "박민수" },
+  ],
+  // 방에 설정된 모든 날짜와 시간대를 포함해야 합니다.
+  dates: mockRoomConfig.dates,
+  timeSlots: mockRoomConfig.timeSlots,
+  participantsInfo: [
+    {
+      date: "2025-10-17",
+      time: "13:00",
+      availableCount: 3,
+      participants: [
+        { id: 1, nickname: "김철수" },
+        { id: 2, nickname: "이영희" },
+        { id: 5, nickname: "박민수" },
+      ],
+    },
+    {
+      date: "2025-10-17",
+      time: "14:00",
+      availableCount: 2,
+      participants: [
+        { id: 3, nickname: "최지우" },
+        { id: 4, nickname: "정수진" },
+      ],
+    },
+    {
+      date: "2025-10-17",
+      time: "15:00",
+      availableCount: 5,
+      participants: [
+        { id: 1, nickname: "김철수" },
+        { id: 2, nickname: "이영희" },
+        { id: 3, nickname: "최지우" },
+        { id: 4, nickname: "정수진" },
+        { id: 5, nickname: "박민수" },
+      ],
+    },
+    {
+      date: "2025-10-17",
+      time: "16:00",
+      availableCount: 4,
+      participants: [
+        { id: 1, nickname: "김철수" },
+        { id: 2, nickname: "이영희" },
+        { id: 4, nickname: "정수진" },
+        { id: 5, nickname: "박민수" },
+      ],
+    },
+    {
+      date: "2025-10-17",
+      time: "17:00",
+      availableCount: 2,
+      participants: [
+        { id: 1, nickname: "김철수" },
+        { id: 2, nickname: "이영희" },
+      ],
+    },
+    {
+      date: "2025-10-20",
+      time: "14:00",
+      availableCount: 3,
+      participants: [
+        { id: 1, nickname: "김철수" },
+        { id: 3, nickname: "최지우" },
+        { id: 4, nickname: "정수진" },
+      ],
+    },
+    {
+      date: "2025-10-22",
+      time: "16:00",
+      availableCount: 1,
+      participants: [{ id: 1, nickname: "김철수" }],
+    },
+  ],
+};

--- a/src/features/result/components/ResultCard.js
+++ b/src/features/result/components/ResultCard.js
@@ -1,0 +1,177 @@
+import React from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+
+// 결과 화면 카드 및 관련 컴포넌트에서 사용하는 테마
+export const resultTheme = {
+  colors: {
+    primary: "dodgerblue",
+    secondary: "gray",
+    text: "#333",
+    textSecondary: "#555",
+    textMuted: "#999",
+    border: "#eee",
+    background: "#f9f9f9",
+    white: "#fff",
+    success: "#e0f8e9",
+    danger: "#fde2e2",
+  },
+  spacing: {
+    xs: 4,
+    sm: 8,
+    smed: 6, // small-medium, 6px 간격
+    md: 10,
+    lg: 15,
+    container: 20,
+    section: 30,
+    buttonVertical: 15,
+    buttonBottom: 10,
+  },
+  fontSize: {
+    xs: 12,
+    sm: 13,
+    base: 14,
+    lg: 15,
+    xl: 16,
+    h3: 20,
+    title: 24,
+  },
+  borderRadius: {
+    sm: 4,
+    md: 8,
+    default: 10,
+  },
+};
+
+// ResultCard 컴포넌트의 스타일
+const cardStyles = StyleSheet.create({
+  slotItem: {
+    backgroundColor: resultTheme.colors.background,
+    borderRadius: resultTheme.borderRadius.md,
+    marginBottom: resultTheme.spacing.md,
+    padding: resultTheme.spacing.lg,
+    borderWidth: 1,
+    borderColor: resultTheme.colors.border,
+  },
+  slotHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  slotRank: {
+    fontSize: resultTheme.fontSize.base,
+    fontWeight: 'bold',
+    color: resultTheme.colors.primary,
+    width: 50,
+  },
+  slotDateTime: {
+    flex: 1,
+    fontSize: resultTheme.fontSize.lg,
+    fontWeight: '500',
+    color: resultTheme.colors.text,
+  },
+  slotCount: {
+    fontSize: resultTheme.fontSize.base,
+    color: resultTheme.colors.textSecondary,
+  },
+  slotDetails: {
+    marginTop: resultTheme.spacing.lg,
+    paddingTop: resultTheme.spacing.lg,
+    borderTopWidth: 1,
+    borderTopColor: resultTheme.colors.border,
+  },
+  participantSection: {
+    marginBottom: resultTheme.spacing.md,
+  },
+  participantTitle: {
+    fontSize: resultTheme.fontSize.base,
+    fontWeight: '600',
+    marginBottom: resultTheme.spacing.sm,
+  },
+  participantList: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  participantName: {
+    borderRadius: resultTheme.borderRadius.sm,
+    paddingVertical: resultTheme.spacing.xs,
+    paddingHorizontal: resultTheme.spacing.sm,
+    marginRight: resultTheme.spacing.smed,
+    marginBottom: resultTheme.spacing.smed,
+    fontSize: resultTheme.fontSize.sm,
+  },
+  availableParticipantName: {
+    backgroundColor: resultTheme.colors.success,
+  },
+  unavailableParticipantName: {
+    backgroundColor: resultTheme.colors.danger,
+  },
+  noParticipantText: {
+    color: resultTheme.colors.textMuted,
+    fontSize: resultTheme.fontSize.sm,
+  },
+});
+
+// 참여자 목록(가능/불가능)을 렌더링하는 함수
+function renderParticipantList(title, participants, isAvailable) {
+  const safeParticipants = Array.isArray(participants) ? participants : [];
+
+  return (
+    <View style={cardStyles.participantSection}>
+      <Text style={cardStyles.participantTitle}>
+        {title} ({safeParticipants.length}명)
+      </Text>
+      {safeParticipants.length > 0 ? (
+        <View style={cardStyles.participantList}>
+          {safeParticipants.map((participant) => (
+            <Text
+              key={participant.id}
+              style={[
+                cardStyles.participantName,
+                isAvailable ? cardStyles.availableParticipantName : cardStyles.unavailableParticipantName,
+              ]}
+            >
+              {participant.nickname}
+            </Text>
+          ))}
+        </View>
+      ) : (
+        <Text style={cardStyles.noParticipantText}>-</Text>
+      )}
+    </View>
+  );
+}
+
+// 추천 시간대를 보여주는 카드 컴포넌트
+export function ResultCard({ slot, index, isExpanded, onToggle, totalParticipants }) {
+  if (!slot) {
+    return null;
+  }
+
+  return (
+    <View style={cardStyles.slotItem}>
+      {/* 추천 시간 헤더 - 누르면 확장/축소 */}
+      <Pressable
+        style={({ pressed }) => [
+          cardStyles.slotHeader,
+          { opacity: pressed ? 0.7 : 1.0 },
+        ]}
+        onPress={() => onToggle(slot.dateTime)}
+      >
+        <Text style={cardStyles.slotRank}>{index + 1}</Text>
+        <Text style={cardStyles.slotDateTime}>{slot.dateTime}</Text>
+        <Text style={cardStyles.slotCount}>
+          {slot.availableCount} / {totalParticipants} 명
+        </Text>
+      </Pressable>
+      {/* 확장 시 보이는 정보 */}
+      {isExpanded && (
+        <View style={cardStyles.slotDetails}>
+          {renderParticipantList("가능한 사람", slot.participants, true)}
+          {renderParticipantList("불가능한 사람", slot.unavailableParticipants, false)}
+        </View>
+      )}
+    </View>
+  );
+}
+
+export default ResultCard;

--- a/src/features/result/hooks/useResult.js
+++ b/src/features/result/hooks/useResult.js
@@ -1,0 +1,86 @@
+import { useState, useEffect, useMemo } from 'react';
+import { LayoutAnimation } from 'react-native';
+import { getRoomResult } from '../services/resultApi';
+
+ // 약속 결과 데이터를 가져오고 UI에 맞게 가공하는 커스텀 훅
+export function useResult(roomId) {
+  const [resultData, setResultData] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);  
+  const [error, setError] = useState(null); 
+  const [expandedSlotId, setExpandedSlotId] = useState(null); 
+
+  // roomId가 변경될 때마다 서버에서 약속 결과 데이터를 가져옴
+  useEffect(() => {
+    const fetchResult = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const data = await getRoomResult(roomId);
+        setResultData(data);
+      } catch (err) {
+        console.error("Failed to fetch result data:", err);
+        setError(err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (roomId) {
+      fetchResult();
+    }
+  }, [roomId]);
+
+  // TimeTable 컴포넌트에 전달할 참여 가능 인원수 데이터를 가공
+  const availabilityData = useMemo(() => {
+    if (!resultData) return null;
+    return {
+      counts: new Map(
+        resultData.participantsInfo.map((slot) => [
+          `${slot.date} ${slot.time}`,
+          slot.availableCount,
+        ])
+      ),
+      total: resultData.roomInfo.totalParticipants,
+    };
+  }, [resultData]);
+
+  // TimeTable 컴포넌트에 전달할 전체 시간 목록을 생성
+  const availableTimes = useMemo(() => {
+    if (!resultData) return [];
+    return resultData.dates.flatMap((date) =>
+      resultData.timeSlots.map((time) => `${date} ${time}`)
+    );
+  }, [resultData]);
+
+
+  // 가장 참여율이 높은 상위 3개의 시간대를 계산하고 각 시간대별 불참자 명단을 추가
+  const topAvailableSlots = useMemo(() => {
+    if (!resultData || !resultData.participantsInfo) return [];
+
+    const allParticipants = resultData.allParticipants || [];
+
+    return [...resultData.participantsInfo]
+      .sort((a, b) => b.availableCount - a.availableCount)
+      .slice(0, 3)
+      .map((slot) => {
+        const availableIds = new Set(slot.participants.map((p) => p.id));
+        const unavailableParticipants = allParticipants.filter(
+          (p) => !availableIds.has(p.id)
+        );
+
+        return {
+          ...slot,
+          dateTime: `${slot.date} ${slot.time}`,
+          unavailableParticipants,
+        };
+      });
+  }, [resultData]);
+
+  // 추천 시간 카드의 확장/축소 상태를 토글
+  const toggleExpand = (slotId) => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setExpandedSlotId(expandedSlotId === slotId ? null : slotId);
+  };
+
+  return { isLoading, error, resultData, availabilityData, availableTimes, topAvailableSlots, expandedSlotId, toggleExpand };
+}

--- a/src/features/result/hooks/useResult.js
+++ b/src/features/result/hooks/useResult.js
@@ -82,5 +82,14 @@ export function useResult(roomId) {
     setExpandedSlotId(expandedSlotId === slotId ? null : slotId);
   };
 
-  return { isLoading, error, resultData, availabilityData, availableTimes, topAvailableSlots, expandedSlotId, toggleExpand };
+  return {
+    isLoading,
+    error,
+    resultData,
+    availabilityData,
+    availableTimes,
+    topAvailableSlots,
+    expandedSlotId,
+    toggleExpand
+  };
 }

--- a/src/features/result/screens/ResultScreen.js
+++ b/src/features/result/screens/ResultScreen.js
@@ -22,23 +22,6 @@ export function ResultScreen({ route }) {
     toggleExpand,
   } = useResult(roomId);
 
-  return (
-    <ResultView
-      navigation={navigation}
-      isLoading={isLoading}
-      error={error}
-      availableTimes={availableTimes}
-      availabilityData={availabilityData}
-      topAvailableSlots={topAvailableSlots}
-      expandedSlotId={expandedSlotId}
-      toggleExpand={toggleExpand}
-      totalParticipants={resultData?.roomInfo.totalParticipants}
-      roomId={roomId}
-    />
-  );
-}
-
-function ResultView({ navigation, isLoading, error, availableTimes, availabilityData, topAvailableSlots, expandedSlotId, toggleExpand, totalParticipants, roomId }) {
   if (isLoading) {
     return <View style={styles.centered}><ActivityIndicator size="large" /></View>;
   }
@@ -68,7 +51,7 @@ function ResultView({ navigation, isLoading, error, availableTimes, availability
               index={index}
               isExpanded={expandedSlotId === slot.dateTime}
               onToggle={toggleExpand}
-              totalParticipants={totalParticipants}
+              totalParticipants={resultData?.roomInfo.totalParticipants}
             />
           ))}
         </View>

--- a/src/features/result/screens/ResultScreen.js
+++ b/src/features/result/screens/ResultScreen.js
@@ -32,8 +32,12 @@ export function ResultScreen({ route }) {
 
   return (
     <ScrollView style={styles.container}>
-      <View style={styles.contentContainer}>
-        <Text style={styles.title}>결과</Text>
+      <View style={null}>
+        <View style={styles.header}>
+          <Text style={styles.title}>결과</Text>
+          <Text style={styles.roomName}>{resultData ? resultData.roomInfo.title : "방 제목"}</Text>
+        </View>
+        
         {/* 전체 시간표를 결과 모드로 렌더링 */}
         <TimeTable
           times={availableTimes}
@@ -56,15 +60,17 @@ export function ResultScreen({ route }) {
           ))}
         </View>
       </View>
+      <View style={styles.buttonContainer}>
+        <Pressable
+          style={styles.editButton}
+          onPress={() => navigation.navigate("TimeSetting", { roomId })}>
+          <Text style={styles.editButtonText}>수정하기</Text>
+        </Pressable>
+        <Pressable style={styles.toDashboardButton} onPress={() => navigation.navigate("Dashboard")}>
+          <Text style={styles.toDashboardButtonText}>목록으로</Text>
+        </Pressable>
+      </View>
 
-      <Pressable
-        style={styles.editButton}
-        onPress={() => navigation.navigate("TimeSetting", { roomId })}>
-        <Text style={styles.editButtonText}>수정하기</Text>
-      </Pressable>
-      <Pressable style={styles.toDashboardButton} onPress={() => navigation.navigate("Dashboard")}>
-        <Text style={styles.toDashboardButtonText}>목록으로</Text>
-      </Pressable>
     </ScrollView>
   );
 }
@@ -92,27 +98,25 @@ const SPACING_BUTTON_BOTTOM = 10;
 const BORDER_RADIUS_DEFAULT = 10;
 
 const styles = StyleSheet.create({
+  header: {padding: 20, borderBottomWidth: 1, borderColor: "#eee",},
   container: {
     flex: 1,
     backgroundColor: COLOR_WHITE,
-    paddingTop: SPACING_CONTAINER,
-  },
-  contentContainer: {
-    padding: SPACING_CONTAINER,
   },
   title: {
     fontSize: FONT_SIZE_TITLE,
     fontWeight: FONT_WEIGHT_BOLD,
-    marginBottom: SPACING_CONTAINER,
   },
+  roomName: { fontSize: 16, color: "gray", marginTop: 4 },
   centered: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
   },
   recommendationContainer: {
+    padding: SPACING_CONTAINER,
     marginTop: SPACING_SECTION_TOP,
-    paddingBottom: SPACING_CONTAINER,
+    marginBottom: SPACING_SECTION_TOP,
   },
   recommendationTitle: {
     fontSize: FONT_SIZE_RECOMMENDATION_TITLE,
@@ -137,6 +141,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   toDashboardButtonText: { color: COLOR_WHITE, fontSize: FONT_SIZE_BUTTON, fontWeight: FONT_WEIGHT_BOLD },
+  buttonContainer: { bottom: 20 },
 });
 
 export default ResultScreen;

--- a/src/features/result/screens/ResultScreen.js
+++ b/src/features/result/screens/ResultScreen.js
@@ -32,33 +32,29 @@ export function ResultScreen({ route }) {
 
   return (
     <ScrollView style={styles.container}>
-      <View style={null}>
-        <View style={styles.header}>
-          <Text style={styles.title}>결과</Text>
-          <Text style={styles.roomName}>{resultData ? resultData.roomInfo.title : "방 제목"}</Text>
-        </View>
-        
-        {/* 전체 시간표를 결과 모드로 렌더링 */}
-        <TimeTable
-          times={availableTimes}
-          availability={availabilityData}
-          readOnly={true}
-        />
-
-        <View style={styles.recommendationContainer}>
-          {/* 추천 시간 목록 */}
-          <Text style={styles.recommendationTitle}>추천 시간 Top 3</Text>
-          {topAvailableSlots.map((slot, index) => (
-            <ResultCard
-              key={slot.dateTime}
-              slot={slot}
-              index={index}
-              isExpanded={expandedSlotId === slot.dateTime}
-              onToggle={toggleExpand}
-              totalParticipants={resultData?.roomInfo.totalParticipants}
-            />
-          ))}
-        </View>
+      <View style={styles.header}>
+        <Text style={styles.title}>결과</Text>
+        <Text style={styles.roomName}>{resultData ? resultData.roomInfo.title : "방 제목"}</Text>
+      </View>
+      {/* 전체 시간표를 결과 모드로 렌더링 */}
+      <TimeTable
+        times={availableTimes}
+        availability={availabilityData}
+        readOnly={true}
+      />
+      <View style={styles.recommendationContainer}>
+        {/* 추천 시간 목록 */}
+        <Text style={styles.recommendationTitle}>추천 시간 Top 3</Text>
+        {topAvailableSlots.map((slot, index) => (
+          <ResultCard
+            key={slot.dateTime}
+            slot={slot}
+            index={index}
+            isExpanded={expandedSlotId === slot.dateTime}
+            onToggle={toggleExpand}
+            totalParticipants={resultData?.roomInfo.totalParticipants}
+          />
+        ))}
       </View>
       <View style={styles.buttonContainer}>
         <Pressable

--- a/src/features/result/screens/ResultScreen.js
+++ b/src/features/result/screens/ResultScreen.js
@@ -1,10 +1,159 @@
-import React from "react";
-import { View, Text } from "react-native";
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, Pressable, ActivityIndicator, } from 'react-native';
+import { useNavigation } from "@react-navigation/native";
+import { TimeTable } from "../../../shared/components/TimeTable";
+import { ResultCard } from "../components/ResultCard";
+import { useResult } from "../hooks/useResult";
 
-export function ResultScreen() {
+export function ResultScreen({ route }) {
+  const navigation = useNavigation();
+  const {
+    roomId = 1,
+  } = route.params || {};
+
+  const {
+    isLoading,
+    error,
+    resultData,
+    availabilityData,
+    availableTimes,
+    topAvailableSlots,
+    expandedSlotId,
+    toggleExpand,
+  } = useResult(roomId);
+
   return (
-    <View>
-      <Text>결과 화면입니다</Text>
-    </View>
+    <ResultView
+      navigation={navigation}
+      isLoading={isLoading}
+      error={error}
+      availableTimes={availableTimes}
+      availabilityData={availabilityData}
+      topAvailableSlots={topAvailableSlots}
+      expandedSlotId={expandedSlotId}
+      toggleExpand={toggleExpand}
+      totalParticipants={resultData?.roomInfo.totalParticipants}
+      roomId={roomId}
+    />
   );
 }
+
+function ResultView({ navigation, isLoading, error, availableTimes, availabilityData, topAvailableSlots, expandedSlotId, toggleExpand, totalParticipants, roomId }) {
+  if (isLoading) {
+    return <View style={styles.centered}><ActivityIndicator size="large" /></View>;
+  }
+
+  if (error) {
+    return <View style={styles.centered}><Text>데이터를 불러오는 데 실패했습니다.</Text></View>;
+  }
+
+  return (
+    <ScrollView style={styles.container}>
+      <View style={styles.contentContainer}>
+        <Text style={styles.title}>결과</Text>
+        {/* 전체 시간표를 결과 모드로 렌더링 */}
+        <TimeTable
+          times={availableTimes}
+          availability={availabilityData}
+          readOnly={true}
+        />
+
+        <View style={styles.recommendationContainer}>
+          {/* 추천 시간 목록 */}
+          <Text style={styles.recommendationTitle}>추천 시간 Top 3</Text>
+          {topAvailableSlots.map((slot, index) => (
+            <ResultCard
+              key={slot.dateTime}
+              slot={slot}
+              index={index}
+              isExpanded={expandedSlotId === slot.dateTime}
+              onToggle={toggleExpand}
+              totalParticipants={totalParticipants}
+            />
+          ))}
+        </View>
+      </View>
+
+      <Pressable
+        style={styles.editButton}
+        onPress={() => navigation.navigate("TimeSetting", { roomId })}>
+        <Text style={styles.editButtonText}>수정하기</Text>
+      </Pressable>
+      <Pressable style={styles.toDashboardButton} onPress={() => navigation.navigate("Dashboard")}>
+        <Text style={styles.toDashboardButtonText}>목록으로</Text>
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+
+// 색상
+const COLOR_PRIMARY = "dodgerblue";
+const COLOR_SECONDARY = "gray";
+const COLOR_WHITE = "#fff";
+
+// 폰트
+const FONT_SIZE_TITLE = 24;
+const FONT_SIZE_RECOMMENDATION_TITLE = 20;
+const FONT_SIZE_BUTTON = 16;
+const FONT_WEIGHT_BOLD = "bold";
+
+// 간격
+const SPACING_CONTAINER = 20;
+const SPACING_SECTION_TOP = 30;
+const SPACING_RECOMMENDATION_BOTTOM = 15;
+const SPACING_BUTTON_VERTICAL = 15;
+const SPACING_BUTTON_BOTTOM = 10;
+
+// 테두리
+const BORDER_RADIUS_DEFAULT = 10;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: COLOR_WHITE,
+    paddingTop: SPACING_CONTAINER,
+  },
+  contentContainer: {
+    padding: SPACING_CONTAINER,
+  },
+  title: {
+    fontSize: FONT_SIZE_TITLE,
+    fontWeight: FONT_WEIGHT_BOLD,
+    marginBottom: SPACING_CONTAINER,
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  recommendationContainer: {
+    marginTop: SPACING_SECTION_TOP,
+    paddingBottom: SPACING_CONTAINER,
+  },
+  recommendationTitle: {
+    fontSize: FONT_SIZE_RECOMMENDATION_TITLE,
+    fontWeight: FONT_WEIGHT_BOLD,
+    marginBottom: SPACING_RECOMMENDATION_BOTTOM,
+  },
+  editButton: {
+    backgroundColor: COLOR_PRIMARY,
+    padding: SPACING_BUTTON_VERTICAL,
+    marginHorizontal: SPACING_CONTAINER,
+    marginBottom: SPACING_BUTTON_BOTTOM,
+    borderRadius: BORDER_RADIUS_DEFAULT,
+    alignItems: "center",
+  },
+  editButtonText: { color: COLOR_WHITE, fontSize: FONT_SIZE_BUTTON, fontWeight: FONT_WEIGHT_BOLD },
+  toDashboardButton: {
+    backgroundColor: COLOR_SECONDARY,
+    padding: SPACING_BUTTON_VERTICAL,
+    marginHorizontal: SPACING_CONTAINER,
+    marginBottom: SPACING_CONTAINER,
+    borderRadius: BORDER_RADIUS_DEFAULT,
+    alignItems: "center",
+  },
+  toDashboardButtonText: { color: COLOR_WHITE, fontSize: FONT_SIZE_BUTTON, fontWeight: FONT_WEIGHT_BOLD },
+});
+
+export default ResultScreen;

--- a/src/features/result/services/resultApi.js
+++ b/src/features/result/services/resultApi.js
@@ -1,0 +1,16 @@
+// 이 파일은 결과 화면에 필요한 데이터를 서버로부터 가져오는 함수들을 정의합니다.
+// 현재는 모의(mock) 데이터로 대체되어 있습니다.
+import { mockResultData } from "../../../data/mockData";
+
+/**
+ * 특정 방의 결과 데이터를 가져오는 API 함수 (모의)
+ * @param {number} roomId - 방의 ID
+ * @returns {Promise<object>} - 결과 데이터
+ */
+export const getRoomResult = (roomId) => {
+  // eslint-disable-next-line no-console
+  console.log(`GET /api/rooms/${roomId}/result`);
+  // 실제 앱에서는 fetch 또는 axios를 사용하여 서버와 통신합니다.
+  // Promise.resolve를 사용하여 비동기 동작을 시뮬레이션합니다.
+  return Promise.resolve(mockResultData);
+};

--- a/src/features/timeSetting/hooks/useTimeSetting.js
+++ b/src/features/timeSetting/hooks/useTimeSetting.js
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
+import { useNavigation } from "@react-navigation/native";
 import { getRoomInfo, postAvailableTimes } from "../services/timeSettingApi";
 
 export function useTimeSetting(roomId) {
   const [room, setRoom] = useState(null);
   const [times, setTimes] = useState([]);
   const [selected, setSelected] = useState(new Set());
+  const navigation = useNavigation();
 
   // 방 정보 불러오기
   useEffect(() => {
@@ -17,7 +19,7 @@ export function useTimeSetting(roomId) {
         const generatedTimes = data.dates.flatMap((date) =>
           data.timeSlots.map((time) => `${date} ${time}`)
         );
-        console.log(generatedTimes);
+        // console.log(generatedTimes);
         setTimes(generatedTimes);
       }
     };
@@ -35,10 +37,12 @@ export function useTimeSetting(roomId) {
   };
 
   // 등록하기
-  const submit = async (navigation) => {
+  const submit = async () => {
     const result = await postAvailableTimes(roomId, Array.from(selected));
     if (result.success) {
-      navigation.navigate("Result");
+      navigation.navigate("Result", {
+        roomId: roomId,
+      });
     }
     return result.success;
   };

--- a/src/features/timeSetting/screens/TimeSettingScreen.js
+++ b/src/features/timeSetting/screens/TimeSettingScreen.js
@@ -1,17 +1,15 @@
 import React from "react";
-import { View, Text, Pressable, Alert, StyleSheet, ScrollView, } from "react-native";
-import { useNavigation } from "@react-navigation/native";
+import { View, Text, Pressable, StyleSheet } from "react-native";
 import { useTimeSetting } from "../hooks/useTimeSetting";
-import { TimeSelector } from "../components/TimeSelector";
+import { TimeTable } from "../../../shared/components/TimeTable";
 
-export function TimeSettingScreen() {
-  const navigation = useNavigation();
-  const roomId = 1;
-  const { room, times, selected, toggle, submit } =
+export function TimeSettingScreen({ route }) {
+  const { roomId = 1 } = route.params || {};
+  const { room, times, selected, toggle, submit } = 
     useTimeSetting(roomId) || {};
 
   const handleSubmit = () => {
-    submit(navigation);
+    submit();
   };
 
   return (
@@ -27,7 +25,7 @@ export function TimeSettingScreen() {
         </Text>
       </View>
       <View style={styles.selectorContainer}>
-        <TimeSelector times={times} selected={selected} toggle={toggle} />
+        <TimeTable times={times} selected={selected} toggle={toggle} />
       </View>
       <Pressable style={styles.submitButton} onPress={handleSubmit}>
         <Text style={styles.submitButtonText}>등록하기</Text>
@@ -41,7 +39,7 @@ const styles = StyleSheet.create({
   header: { padding: 20, borderBottomWidth: 1, borderColor: "#eee" },
   title: { fontSize: 24, fontWeight: "bold" },
   participants: { fontSize: 16, color: "gray", marginTop: 4 },
-  selectorContainer: { flex: 1 },
+  selectorContainer: { flex: 1, padding: 0, },
   submitButton: {
     backgroundColor: "dodgerblue",
     padding: 15,

--- a/src/features/timeSetting/services/timeSettingApi.js
+++ b/src/features/timeSetting/services/timeSettingApi.js
@@ -1,18 +1,11 @@
+import { mockRoomConfig } from "../../../data/mockData";
+
 // 서버 통신 관련 (임시로 콘솔 로그로 대체)
 export const getRoomInfo = (roomId) => {
   // eslint-disable-next-line no-console
   console.log(`GET /api/rooms/${roomId}`);
   // 실제로는 fetch로 불러오면 됨
-  return {
-    roomId: 1,
-    title: "스터디 모임",
-    dates: ["2025-10-15", "2025-10-17", "2025-10-20", "2025-10-21"],
-    timeSlots: ["09:00", "13:00", "14:00", "15:00", "16:00", "17:00", "18:00", "19:00"],
-    isOwner: false,
-    hasResponded: false,
-    totalParticipants: 5,
-    respondedCount: 3,
-  };
+  return mockRoomConfig;
 };
 
 export const postAvailableTimes = (roomId, times) => {

--- a/src/shared/components/TimeTable.js
+++ b/src/shared/components/TimeTable.js
@@ -1,8 +1,49 @@
 import React from "react";
 import { View, Text, Pressable, StyleSheet, ScrollView } from "react-native";
 
-export function TimeSelector({ times, selected, toggle }) {
-  // 1. 데이터를 그리드에 맞게 가공
+const TimeCell = React.memo(function TimeCell({
+  date,
+  time,
+  isSelected,
+  availability,
+  readOnly,
+  onPress,
+}) {
+  const dateTime = `${date} ${time}`;
+
+  // 참여 가능 인원 수에 따라 셀의 배경색 투명도를 계산합니다.
+  // availability나 dateTime이 변경될 때만 재계산하여 성능을 최적화합니다.
+  const cellStyle = React.useMemo(() => {
+    if (availability?.counts.has(dateTime)) {
+      const count = availability.counts.get(dateTime);
+      const total = availability.total || 1;
+      // 0으로 나누는 것을 방지하고, 최소 투명도를 보장합니다.
+      const opacity = total > 0 ? Math.max(0.1, count / total) : 0.1;
+      return {
+        backgroundColor: `rgba(30, 144, 255, ${opacity})`,
+      };
+    }
+    return {};
+  }, [availability, dateTime]);
+
+  return (
+    <Pressable
+      disabled={readOnly}
+      onPress={() => onPress && onPress(dateTime)}
+      style={[styles.cell, cellStyle, isSelected && styles.selectedCell]}
+    />
+  );
+});
+
+export function TimeTable({
+  times,
+  selected = new Set(),
+  toggle,
+  readOnly = false,
+  availability,
+}) {
+  // 1. `times` 배열을 날짜(dates)와 시간(timeSlots)으로 분리하여 그리드 구조로 가공합니다.
+  // `useMemo`를 사용하여 `times` prop이 변경될 때만 이 비싼 연산을 수행하도록 최적화합니다.
   const { dates, timeSlots } = React.useMemo(() => {
     if (!times || times.length === 0) {
       return { dates: [], timeSlots: [] };
@@ -23,11 +64,12 @@ export function TimeSelector({ times, selected, toggle }) {
     };
   }, [times]);
 
+  // 선택 가능한 시간이 없으면 메시지를 표시합니다.
   if (dates.length === 0) {
     return <Text>선택 가능한 시간이 없습니다.</Text>;
   }
 
-  // 2. 그리드 렌더링
+  // 2. 가공된 데이터를 기반으로 시간표 그리드를 렌더링합니다.
   return (
     <ScrollView horizontal>
       <View>
@@ -48,13 +90,17 @@ export function TimeSelector({ times, selected, toggle }) {
               <Text>{time}</Text>
             </View>
             {dates.map((date) => {
+              // `TimeCell` 컴포넌트를 사용하여 각 시간대별 셀을 렌더링합니다.
               const dateTime = `${date} ${time}`;
-              const isSelected = selected.has(dateTime);
               return (
-                <Pressable
+                <TimeCell
                   key={dateTime}
-                  onPress={() => toggle(dateTime)}
-                  style={[styles.cell, isSelected && styles.selectedCell]}
+                  date={date}
+                  time={time}
+                  isSelected={selected.has(dateTime)}
+                  availability={availability}
+                  readOnly={readOnly}
+                  onPress={toggle}
                 />
               );
             })}
@@ -65,16 +111,20 @@ export function TimeSelector({ times, selected, toggle }) {
   );
 }
 
+// --- 스타일 정의 ---
 
+// 그리드 레이아웃 관련 상수
 const DAY_CELL_WIDTH = 65;
 const TIME_LABEL_CELL_WIDTH = 60;
 const CELL_HEIGHT = 40;
 const DEFAULT_PADDING = 10;
 
+// 테두리 두께 관련 상수
 const HEADER_BORDER_WIDTH = 1;
 const TIME_LABEL_BORDER_WIDTH = 1;
 const CELL_BORDER_WIDTH = 0.5;
 
+// 색상 및 폰트 관련 상수
 const GRID_BORDER_COLOR = "#ccc";
 const CELL_BORDER_COLOR = "#eee";
 const SELECTED_CELL_BACKGROUND = "dodgerblue";
@@ -99,13 +149,13 @@ const styles = StyleSheet.create({
     borderRightWidth: TIME_LABEL_BORDER_WIDTH,
     borderColor: GRID_BORDER_COLOR,
   },
-  cell: { 
-    width: DAY_CELL_WIDTH, 
-    height: CELL_HEIGHT, 
-    borderWidth: CELL_BORDER_WIDTH, 
-    borderColor: CELL_BORDER_COLOR 
+  cell: {
+    width: DAY_CELL_WIDTH,
+    height: CELL_HEIGHT,
+    borderWidth: CELL_BORDER_WIDTH,
+    borderColor: CELL_BORDER_COLOR,
   },
-  selectedCell: { 
-    backgroundColor: SELECTED_CELL_BACKGROUND 
+  selectedCell: {
+    backgroundColor: SELECTED_CELL_BACKGROUND,
   },
 });


### PR DESCRIPTION
## 📋 변경 사항

<!-- 어떤 변경사항이 있는지 간단히 설명해주세요 -->
결과 페이지 UI를 제작했습니다. 
참여자의 가능한 시간을 취합한 시간표와 추천 Top3 약속 시간을 한눈에 확인할 수 있습니다.

## 🔗 관련 이슈

Closes #13 

## 📝 작업 내용

- [ ] ResultScreen.js: 결과 화면 컴포넌트 추가, 로딩/에러 처리, TimeTable 결과 모드 렌더링, 추천 Top3 리스트 및 수정 및 목록 네이게이션 버튼 추가
- [ ] ResultCard.js: 추천 시간 UI 컴포넌트 (클릭하여, 가능/불가능 인원 확인 가능)
- [ ] useResult.js: 결과 데이터 가공 로직 추가 (Top3 계산, 확장 토글, 참여자 수)
- [ ] resultApi: 모의 데이터 반환
- [ ] mockData.js: mockRoomConfig, mockResultData 추가
- [ ] TimeTable.js: TimeSelector.js에서 명칭을 TimeTable로 교체

## 📸 스크린샷 (UI 변경 시)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="720" height="1984" alt="image" src="https://github.com/user-attachments/assets/33e12654-7557-4950-8c37-bc9f515b79f8" />


## 🔍 리뷰 포인트 (선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 적어주세요 -->
- useResult 훅의 데이터 가공 및 Top3 계산 로직 구조 적절성
- ResultCard 확장/축소 애니메이션 처리 및 레이아웃 안정성
- TimeTable 결과 모드에서 색상 시각화 기준 검토