### PR TITLE
[Feat] #19 닉네임 설정 페이지 구현

### DIFF
--- a/src/features/auth/screens/LoginScreen.js
+++ b/src/features/auth/screens/LoginScreen.js
@@ -16,7 +16,8 @@ export function LoginScreen() {
 
   const handleLogin = (type) => {
     console.log(`${type} 로그인 시도`);
-    navigation.navigate("Dashboard");
+    // TODO: 실제 소셜 로그인 로직 구현 후, 성공 시 아래 코드로 닉네임 설정 화면으로 이동
+    navigation.navigate("NicknameSetup");
   };
 
   return (

--- a/src/features/auth/screens/NicknameSetupScreen.js
+++ b/src/features/auth/screens/NicknameSetupScreen.js
@@ -1,0 +1,116 @@
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+  Alert,
+  TouchableWithoutFeedback,
+  Keyboard,
+} from "react-native";
+import { useNavigation } from "@react-navigation/native";
+
+export function NicknameSetupScreen() {
+  const [nickname, setNickname] = useState("");
+  const navigation = useNavigation();
+
+  const handleConfirm = () => {
+    if (nickname.trim().length < 2) {
+      Alert.alert("알림", "닉네임은 2자 이상으로 입력해주세요.");
+      return;
+    }
+    // TODO: 닉네임 저장 API 호출 또는 상태 관리 로직 추가
+    console.log(`설정된 닉네임: ${nickname}`);
+    navigation.reset({
+      index: 0,
+      routes: [{ name: "Dashboard" }],
+    });
+  };
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
+      style={styles.container}
+    >
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+        <View style={styles.inner}>
+          <Text style={styles.title}>환영합니다!</Text>
+          <Text style={styles.subtitle}>
+            사용하실 닉네임을 입력해주세요.
+          </Text>
+          <TextInput
+            style={styles.input}
+            value={nickname}
+            onChangeText={setNickname}
+            placeholder="닉네임 (2자 이상)"
+            placeholderTextColor="#999"
+            autoFocus={true}
+            returnKeyType="done"
+            onSubmitEditing={handleConfirm}
+          />
+          <TouchableOpacity
+            style={[
+              styles.button,
+              nickname.trim().length < 2 && styles.buttonDisabled,
+            ]}
+            onPress={handleConfirm}
+            disabled={nickname.trim().length < 2}
+          >
+            <Text style={styles.buttonText}>시작하기</Text>
+          </TouchableOpacity>
+        </View>
+      </TouchableWithoutFeedback>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  inner: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 30,
+    backgroundColor: "#fff",
+  },
+  title: { 
+    fontSize: 28, 
+    fontWeight: "bold", 
+    marginBottom: 10 
+},
+  subtitle: { 
+    fontSize: 16, 
+    color: "#666", 
+    textAlign: "center", 
+    marginBottom: 40 
+},
+  input: { 
+    width: "100%", 
+    height: 50, 
+    borderColor: "#ccc", 
+    borderWidth: 1, 
+    borderRadius: 10, 
+    paddingHorizontal: 15, 
+    fontSize: 16, 
+    marginBottom: 20 
+},
+  button: { 
+    width: "100%", 
+    height: 50, 
+    backgroundColor: "dodgerblue", 
+    justifyContent: "center", 
+    alignItems: "center", 
+    borderRadius: 10 
+},
+  buttonDisabled: { 
+    backgroundColor: "#ccc" 
+},
+  buttonText: { 
+    color: "#fff", 
+    fontSize: 18, 
+    fontWeight: "bold" 
+},
+});

--- a/src/features/auth/screens/NicknameSetupScreen.js
+++ b/src/features/auth/screens/NicknameSetupScreen.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import {
   View,
   Text,
@@ -10,19 +10,30 @@ import {
   Alert,
   TouchableWithoutFeedback,
   Keyboard,
+  Image,
+  useWindowDimensions,
 } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 
 export function NicknameSetupScreen() {
   const [nickname, setNickname] = useState("");
   const navigation = useNavigation();
+  const { width, height } = useWindowDimensions();
+
+  // 닉네임 유효성 검사 (1~12자, 특수문자 및 공백 제외)
+  const isNicknameValid = useMemo(() => {
+    const regex = /^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣]{1,12}$/;
+    return regex.test(nickname);
+  }, [nickname]);
 
   const handleConfirm = () => {
-    if (nickname.trim().length < 2) {
-      Alert.alert("알림", "닉네임은 2자 이상으로 입력해주세요.");
+    if (!isNicknameValid) {
+      Alert.alert(
+        "알림",
+        "닉네임은 1~12자의 한글, 영문, 숫자만 사용할 수 있습니다."
+      );
       return;
     }
-    // TODO: 닉네임 저장 API 호출 또는 상태 관리 로직 추가
     console.log(`설정된 닉네임: ${nickname}`);
     navigation.reset({
       index: 0,
@@ -44,20 +55,24 @@ export function NicknameSetupScreen() {
           <TextInput
             style={styles.input}
             value={nickname}
-            onChangeText={setNickname}
-            placeholder="닉네임 (2자 이상)"
+            onChangeText={(text) => setNickname(text.replace(/\s/g, ""))} // 공백 입력 방지
+            placeholder="닉네임 (1~12자)"
             placeholderTextColor="#999"
             autoFocus={true}
             returnKeyType="done"
             onSubmitEditing={handleConfirm}
+            maxLength={12}
           />
+          <Text style={styles.validationText}>
+            * 1~12자의 한글, 영문, 숫자만 사용 가능합니다.
+          </Text>
           <TouchableOpacity
             style={[
               styles.button,
-              nickname.trim().length < 2 && styles.buttonDisabled,
+              !isNicknameValid && styles.buttonDisabled,
             ]}
             onPress={handleConfirm}
-            disabled={nickname.trim().length < 2}
+            disabled={!isNicknameValid}
           >
             <Text style={styles.buttonText}>시작하기</Text>
           </TouchableOpacity>
@@ -76,10 +91,19 @@ const styles = StyleSheet.create({
     paddingHorizontal: 30,
     backgroundColor: "#fff",
   },
+  logoContainer: {
+    alignItems: "center",
+    marginBottom: "15%",
+    marginTop: "5%",
+  },
+  logo: {
+    alignSelf: "center",
+  },
   title: { 
     fontSize: 28, 
     fontWeight: "bold", 
-    marginBottom: 10 
+    marginBottom: 10,
+    color: "#333",
 },
   subtitle: { 
     fontSize: 16, 
@@ -95,7 +119,13 @@ const styles = StyleSheet.create({
     borderRadius: 10, 
     paddingHorizontal: 15, 
     fontSize: 16, 
-    marginBottom: 20 
+    marginBottom: 10,
+},
+  validationText: {
+    width: "100%",
+    fontSize: 12,
+    color: "#666",
+    marginBottom: 20,
 },
   button: { 
     width: "100%", 

--- a/src/navigation/AppNavigation.js
+++ b/src/navigation/AppNavigation.js
@@ -3,6 +3,7 @@ import { NavigationContainer } from "@react-navigation/native";
 import { createStackNavigator } from "@react-navigation/stack";
 
 import { LoginScreen } from "../features/auth/screens/LoginScreen";
+import { NicknameSetupScreen } from "../features/auth/screens/NicknameSetupScreen";
 import { DashboardScreen } from "../features/dashboard/screens/DashboardScreen";
 import { ProfileScreen } from "../features/profile/screens/ProfileScreen";
 import { RoomCreateScreen } from "../features/room/screens/RoomCreateScreen";
@@ -16,6 +17,7 @@ export function AppNavigation() {
     <NavigationContainer>
       <Stack.Navigator>
         <Stack.Screen name="Login" component={LoginScreen} />
+        <Stack.Screen name="NicknameSetup" component={NicknameSetupScreen} />
         <Stack.Screen name="Dashboard" component={DashboardScreen} />
         <Stack.Screen name="Profile" component={ProfileScreen} />
         <Stack.Screen name="RoomCreate" component={RoomCreateScreen} />


### PR DESCRIPTION
## 📋 변경 사항

- 회원가입 후 사용자의 닉네임을 설정하는 화면을 추가

## 🔗 관련 이슈

Closes #19 
## 📝 작업 내용

- [ ] 닉네임 설정 화면 UI 구성
- [ ] 닉네임 유효성 검사 로직 구현 (1~12자, 한글 영문 숫자, 공백 및 특수문자 제외)
- [ ] 유효하지 않은 닉네임일 경우 확인버튼 비활성화
- [ ] 닉네임 설정 완료 시 대시보드 화면으로 이동
- [ ] 키보드 노출 시 화면 가림 방지를 위한 KeyboardAvoidingView 적용 및 외부 터치 시 키보드 닫기 기능 구현

## 📸 스크린샷 (UI 변경 시)

<img width="424" height="922" alt="image" src="https://github.com/user-attachments/assets/342263b8-22c6-4a13-a672-27d007573871" />
<img width="424" height="922" alt="image" src="https://github.com/user-attachments/assets/e8782b19-c469-461e-b3b7-c7938782c1e9" />


## 🔍 리뷰 포인트 (선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 적어주세요 -->
