### PR TITLE
[REFACTOR] #28 소셜 로그인 결과 반환 구조 통합

### DIFF
--- a/src/config/apiConfig.js
+++ b/src/config/apiConfig.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = "https://your-backend.com/api"; // 실제 백엔드 주소로 수정

--- a/src/features/auth/services/AppleLogin.js
+++ b/src/features/auth/services/AppleLogin.js
@@ -1,7 +1,17 @@
+// src/features/auth/services/AppleLogin.js
 import { Platform } from "react-native";
 import * as AppleAuthentication from "expo-apple-authentication";
-import { socialLogin } from "./authApi";
 
+/**
+ * @returns {Promise<{
+ *  provider: "apple",
+ *  socialId: string,
+ *  name: string | null,
+ *  email: string | null,
+ *  avatar: string | null,
+ *  token: string
+ * } | null>}
+ */
 export async function handleAppleLogin() {
   if (Platform.OS !== "ios") {
     console.warn("Apple 로그인은 iOS 전용 기능입니다.");
@@ -16,9 +26,21 @@ export async function handleAppleLogin() {
       ],
     });
 
-    const result = await socialLogin("apple", credential.identityToken);
-    return result.user;
+    if (!credential.identityToken) {
+      console.warn("⚠️ Apple identityToken 없음");
+      return null;
+    }
+
+    return {
+      provider: "apple",
+      socialId: credential.user,
+      name: credential.fullName?.givenName ?? null,
+      email: credential.email ?? null,
+      avatar: null,
+      token: credential.identityToken,
+    };
   } catch (err) {
     console.error("Apple login error:", err);
+    return null;
   }
 }

--- a/src/features/auth/services/GoogleLogin.js
+++ b/src/features/auth/services/GoogleLogin.js
@@ -1,34 +1,54 @@
+// src/features/auth/services/GoogleLogin.js
 import * as WebBrowser from "expo-web-browser";
 import * as Google from "expo-auth-session/providers/google";
-import AsyncStorage from "@react-native-async-storage/async-storage";
-import { socialLogin } from "./authApi";
 
 WebBrowser.maybeCompleteAuthSession();
 
 const WEB_CLIENT_ID =
   "144050250731-t0t3cj67l6p82t2inf5a5ql1pnp5npfl.apps.googleusercontent.com";
 
+/**
+ * @returns {{ handleGoogleLogin: () => Promise<SocialUser | null>, request: any }}
+ */
 export function useGoogleAuth() {
   const [request, response, promptAsync] = Google.useAuthRequest({
-    webClientId: WEB_CLIENT_ID, // ✅ 웹 애플리케이션용 클라이언트 ID
+    webClientId: WEB_CLIENT_ID,
     androidClientId: WEB_CLIENT_ID,
     iosClientId: WEB_CLIENT_ID,
-    redirectUri: "https://auth.expo.io/@yoojihyeon/timefit-app", // ✅ expo 계정 + slug 정확히 일치
+    redirectUri: "https://auth.expo.io/@yoojihyeon/timefit-app",
   });
 
   const handleGoogleLogin = async () => {
     try {
       const result = await promptAsync();
-      if (result?.type === "success") {
-        const token = result.authentication?.accessToken;
-        const data = await socialLogin("google", token);
-        if (data?.accessToken) {
-          await AsyncStorage.setItem("jwt", data.accessToken);
-          return data.user;
-        }
+      if (result?.type !== "success") {
+        console.warn("⚠️ Google 로그인 취소 또는 실패");
+        return null;
       }
+
+      const token = result.authentication?.accessToken;
+      if (!token) {
+        console.warn("⚠️ Google accessToken 없음");
+        return null;
+      }
+
+      // Google 사용자 정보 조회
+      const res = await fetch("https://www.googleapis.com/oauth2/v3/userinfo", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const info = await res.json();
+
+      return {
+        provider: "google",
+        socialId: info.sub,
+        name: info.name ?? null,
+        email: info.email ?? null,
+        avatar: info.picture ?? null,
+        token,
+      };
     } catch (err) {
       console.error("Google login error:", err);
+      return null;
     }
   };
 

--- a/src/features/auth/services/KakaoLogin.js
+++ b/src/features/auth/services/KakaoLogin.js
@@ -1,27 +1,28 @@
+// src/features/auth/services/KakaoLogin.js
 import * as AuthSession from "expo-auth-session";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const KAKAO_REST_API_KEY = "f939f9e98e824f5ce7592923a30ed35c";
 
-// ✅ Expo 개발환경용 redirect URI
 const redirectUri = AuthSession.makeRedirectUri({
-  scheme: "timefit", // app.json의 scheme과 동일
+  scheme: "timefit",
   useProxy: true,
 });
 
-// ✅ Kakao OAuth 설정
 const discovery = {
   authorizationEndpoint: "https://kauth.kakao.com/oauth/authorize",
   tokenEndpoint: "https://kauth.kakao.com/oauth/token",
 };
 
+/**
+ * @returns {{ login: () => Promise<SocialUser | null>, request: any }}
+ */
 export function useKakaoAuth() {
   const [request, response, promptAsync] = AuthSession.useAuthRequest(
     {
       clientId: KAKAO_REST_API_KEY,
       redirectUri,
       responseType: AuthSession.ResponseType.Code,
-      usePKCE: false, // Kakao는 PKCE 미사용
+      usePKCE: false,
     },
     discovery
   );
@@ -29,16 +30,13 @@ export function useKakaoAuth() {
   const login = async () => {
     try {
       const result = await promptAsync({ useProxy: true });
-
       if (result.type !== "success" || !result.params?.code) {
-        console.warn("⚠️ 로그인 취소 또는 실패");
+        console.warn("⚠️ Kakao 로그인 취소 또는 실패");
         return null;
       }
 
       const code = result.params.code;
-      console.log("✅ 인가 코드:", code);
 
-      // 🔑 토큰 요청
       const tokenRes = await fetch(discovery.tokenEndpoint, {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -51,29 +49,31 @@ export function useKakaoAuth() {
       });
 
       const tokenData = await tokenRes.json();
-
-      if (!tokenData.access_token) {
-        console.warn("⚠️ 토큰 요청 실패:", tokenData);
+      const accessToken = tokenData.access_token;
+      if (!accessToken) {
+        console.warn("⚠️ Kakao 토큰 요청 실패:", tokenData);
         return null;
       }
 
-      await AsyncStorage.setItem("kakao_access_token", tokenData.access_token);
-      console.log("🔑 액세스 토큰:", tokenData.access_token);
-
-      // 👤 사용자 정보 요청
       const meRes = await fetch("https://kapi.kakao.com/v2/user/me", {
-        headers: { Authorization: `Bearer ${tokenData.access_token}` },
+        headers: { Authorization: `Bearer ${accessToken}` },
       });
-
       const userInfo = await meRes.json();
-      console.log("👤 사용자 정보:", userInfo);
 
-      return userInfo;
+      return {
+        provider: "kakao",
+        socialId: userInfo.id?.toString() ?? "",
+        name: userInfo.kakao_account?.profile?.nickname ?? null,
+        email: userInfo.kakao_account?.email ?? null,
+        avatar:
+          userInfo.kakao_account?.profile?.profile_image_url ?? null,
+        token: accessToken,
+      };
     } catch (e) {
       console.error("카카오 로그인 오류:", e);
       return null;
     }
   };
 
-  return { login };
+  return { login, request };
 }


### PR DESCRIPTION
## 📋 변경 사항
소셜 로그인(Kakao, Google, Apple)에서 서로 다르게 반환되던 사용자 정보를  
`SocialUser` 공통 구조로 통합하는 리팩토링을 진행했습니다.

## 🔗 관련 이슈
Closes #28

## 📝 작업 내용
- [x] Kakao/Google/Apple 로그인 결과를 SocialUser 통일 구조로 매핑
- [x] provider, socialId, name, email, avatar, token 필드 통일
- [x] 각 플랫폼별 파싱 로직 정리 및 불필요한 중복 제거
- [x] AuthManager에서 loginWithProvider 로직 단순화
- [x] 향후 JWT 연동 및 자동 로그인 로직 확장에 대비한 구조 정비

실수로 커밋 전에 merge를 진행해버려서,
누락된 변경사항만 별도로 다시 커밋해서 PR 올립니다 🙏