### PR TITLE
[FEAT] #31 방 수정 및 삭제 기능 구현

### DIFF
--- a/src/features/dashboard/components/RoomList.js
+++ b/src/features/dashboard/components/RoomList.js
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   Image,
   LayoutAnimation,
+  Alert
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 
@@ -16,18 +17,53 @@ export function RoomList({
   toggleExpand,
   handleInvite,
   navigation,
+  onEdit,
+  onDelete,
 }) {
   const renderRoom = ({ item }) => {
     const isExpanded = expandedRoomId === item.roomNumber;
 
     return (
-      <View style={styles.roomItem}>
+      <TouchableOpacity 
+        style={styles.roomItem}
+        onPress={() =>
+          navigation.navigate("TimeSetting", {
+            roomId: item.roomNumber,
+          })
+        }>
         <View style={styles.roomHeader}>
           <View>
             <Text style={styles.roomTitle}>{item.title}</Text>
             <Text style={styles.roomDate}>{item.date}</Text>
           </View>
           <View style={styles.actions}>
+             <TouchableOpacity
+                onPress={() => onEdit(item)}
+                style={styles.iconButton}
+              >
+                <Ionicons name="create-outline" size={20} color="#007AFF" />
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                onPress={() =>
+                  Alert.alert(
+                    "방 삭제",
+                    `"${item.title}" 방을 정말 삭제하시겠습니까?`,
+                    [
+                      { text: "취소", style: "cancel" },
+                      {
+                        text: "삭제",
+                        style: "destructive",
+                        onPress: () => onDelete(item.roomNumber),
+                      },
+                    ]
+                  )
+                }
+                style={styles.iconButton}
+              >
+                <Ionicons name="trash-outline" size={20} color="#FF3B30" />
+              </TouchableOpacity>
+
             <TouchableOpacity
               onPress={() => handleInvite(item.inviteCode)}
               style={styles.iconButton}
@@ -70,7 +106,7 @@ export function RoomList({
             </View>
           </View>
         )}
-      </View>
+      </TouchableOpacity>
     );
   };
 

--- a/src/features/dashboard/components/RoomList.js
+++ b/src/features/dashboard/components/RoomList.js
@@ -48,7 +48,7 @@ export function RoomList({
                 onPress={() =>
                   Alert.alert(
                     "방 삭제",
-                    `"${item.title}" 방을 정말 삭제하시겠습니까?`,
+                    `"${item.title}" 방을 삭제하시겠습니까?`,
                     [
                       { text: "취소", style: "cancel" },
                       {
@@ -63,6 +63,7 @@ export function RoomList({
               >
                 <Ionicons name="trash-outline" size={20} color="#FF3B30" />
               </TouchableOpacity>
+
 
             <TouchableOpacity
               onPress={() => handleInvite(item.inviteCode)}

--- a/src/features/dashboard/hooks/useDashboard.js
+++ b/src/features/dashboard/hooks/useDashboard.js
@@ -1,31 +1,57 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Alert, LayoutAnimation, Share } from "react-native";
 import * as Clipboard from "expo-clipboard";
 import { mockRooms } from "../../../data/mockData";
 
 export function useDashboard() {
   const [expandedRoomId, setExpandedRoomId] = useState(null);
-  const [rooms] = useState(mockRooms); // 나중에 API 데이터로 교체 예정
+  const [rooms, setRooms] = useState([]);
 
+  // 🔥 대시보드 방 목록 가져오기 (현재는 mock)
+  const fetchRooms = async () => {
+    // 서버 연동되면 여기에 fetch 변경하면 됨
+    setRooms(mockRooms);
+  };
+
+  // 🔥 외부에서 호출할 수 있는 새로고침 함수
+  const refreshRooms = () => {
+    fetchRooms();
+  };
+
+  // 화면 진입 시 1회 실행
+  useEffect(() => {
+    fetchRooms();
+  }, []);
+
+  // 🔗 초대 링크 복사
   const handleInvite = async (inviteCode) => {
-    // ✅ 서버에서 이미 생성된 초대 코드 사용
     const inviteLink = `https://timefit.app/invite?code=${inviteCode}`;
+
     try {
       await Clipboard.setStringAsync(inviteLink);
       await Share.share({
         message: `TimeFit 방에 초대합니다! 🎉\n\n초대 링크: ${inviteLink}`,
       });
+
       Alert.alert("✅ 초대 링크 복사 완료", "공유 창이 열렸습니다!");
-    } catch (error) {
+    } catch (err) {
       Alert.alert("오류", "초대 링크를 복사하는 중 문제가 발생했습니다.");
-      console.error(error);
+      console.error(err);
     }
   };
 
+  // 🔽 방 접기/펼치기
   const toggleExpand = (id) => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     setExpandedRoomId(expandedRoomId === id ? null : id);
   };
 
-  return { rooms, expandedRoomId, handleInvite, toggleExpand };
+  return {
+    rooms,
+    setRooms,
+    refreshRooms,
+    expandedRoomId,
+    handleInvite,
+    toggleExpand,
+  };
 }

--- a/src/features/dashboard/screens/DashboardScreen.js
+++ b/src/features/dashboard/screens/DashboardScreen.js
@@ -33,6 +33,8 @@ export function DashboardScreen() {
         toggleExpand={toggleExpand}
         handleInvite={handleInvite}
         navigation={navigation}
+        onEdit={(room) => navigation.navigate("RoomEdit", { room })}
+        onDelete={(roomNumber) => console.log("삭제:", roomNumber)}
       />
 
       {/* 하단 추가 버튼 */}

--- a/src/features/dashboard/screens/DashboardScreen.js
+++ b/src/features/dashboard/screens/DashboardScreen.js
@@ -4,11 +4,24 @@ import { Ionicons } from "@expo/vector-icons";
 import { useNavigation } from "@react-navigation/native";
 import { RoomList } from "../components/RoomList";
 import { useDashboard } from "../hooks/useDashboard";
+import { useRoom } from "../../room/hooks/useRoom";
 
 export function DashboardScreen() {
   const navigation = useNavigation();
-  const { rooms, handleInvite, expandedRoomId, toggleExpand } = useDashboard();
+  const { rooms, refreshRooms, expandedRoomId, toggleExpand, handleInvite } = useDashboard();
+  const { deleteRoom } = useRoom();
 
+  const handleDelete = async (roomNumber) => {
+    /* const ok = await deleteRoom(roomNumber);
+
+    if (ok) {
+      Alert.alert("삭제 완료", "방이 성공적으로 삭제되었습니다.");
+      // 🔥 Dashboard 새로고침 필요하면 useDashboard()에서 rooms 재요청 처리
+    } */
+    // 🔥 서버 연동 전: 그냥 프론트에서 목록에서만 제거
+    Alert.alert("삭제 완료", "서버 연동 전이라 프론트에서만 삭제합니다.");
+    setRooms((prev) => prev.filter((room) => room.roomNumber !== roomNumber));
+  };
   return (
     <View style={styles.container}>
       {/* 상단 로고 & 프로필 */}
@@ -34,7 +47,7 @@ export function DashboardScreen() {
         handleInvite={handleInvite}
         navigation={navigation}
         onEdit={(room) => navigation.navigate("RoomEdit", { room })}
-        onDelete={(roomNumber) => console.log("삭제:", roomNumber)}
+        onDelete={handleDelete}
       />
 
       {/* 하단 추가 버튼 */}
@@ -53,7 +66,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: "#fff",
     paddingHorizontal: 20,
-    paddingTop: 60,
+    paddingTop: 30,
   },
   header: {
     flexDirection: "row",
@@ -70,7 +83,7 @@ const styles = StyleSheet.create({
   addButton: {
     position: "absolute",
     right: 25,
-    bottom: 40,
+    bottom: 80,
     backgroundColor: "#007AFF",
     width: 65,
     height: 65,

--- a/src/features/dashboard/screens/DashboardScreen.js
+++ b/src/features/dashboard/screens/DashboardScreen.js
@@ -8,19 +8,17 @@ import { useRoom } from "../../room/hooks/useRoom";
 
 export function DashboardScreen() {
   const navigation = useNavigation();
-  const { rooms, refreshRooms, expandedRoomId, toggleExpand, handleInvite } = useDashboard();
+  const { rooms, setRooms, refreshRooms, expandedRoomId, toggleExpand, handleInvite } = useDashboard();
   const { deleteRoom } = useRoom();
 
   const handleDelete = async (roomNumber) => {
-    /* const ok = await deleteRoom(roomNumber);
+    // TODO: 서버 연동 시 deleteRoom(roomNumber) 실행 후 아래 로직으로 교체 예정
 
-    if (ok) {
-      Alert.alert("삭제 완료", "방이 성공적으로 삭제되었습니다.");
-      // 🔥 Dashboard 새로고침 필요하면 useDashboard()에서 rooms 재요청 처리
-    } */
     // 🔥 서버 연동 전: 그냥 프론트에서 목록에서만 제거
     Alert.alert("삭제 완료", "서버 연동 전이라 프론트에서만 삭제합니다.");
-    setRooms((prev) => prev.filter((room) => room.roomNumber !== roomNumber));
+    setRooms((prev) => prev.filter((room) => room.roomNumber !== roomNumber)); // 새로고침
+
+    // TODO: 서버 연동 후 refreshRooms()로 실제 데이터 재요청
   };
   return (
     <View style={styles.container}>

--- a/src/features/room/components/RoomForm.js
+++ b/src/features/room/components/RoomForm.js
@@ -116,12 +116,12 @@ export function RoomForm({ onSubmit, submitLabel = "방 생성" }) {
 
     const requestBody = {
       title,
-      dates: sortedDates, // ✅ 정렬된 날짜 사용
+      dates: sortedDates,
       startTime,
       endTime,
-      createdAt,
+      /* createdAt,
       expiresAt: formattedExpiresAt,
-      owner: "1",
+      owner: "1", */
     };
 
     onSubmit(requestBody);

--- a/src/features/room/components/RoomForm.js
+++ b/src/features/room/components/RoomForm.js
@@ -18,7 +18,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 const ITEM_HEIGHT = 40;
 const VISIBLE_ITEMS = 5;
 
-export function RoomForm({ onSubmit }) {
+export function RoomForm({ onSubmit, submitLabel = "방 생성" }) {
   const [title, setTitle] = useState("");
   const [selectedDates, setSelectedDates] = useState({});
   const [startTime, setStartTime] = useState("");
@@ -277,13 +277,13 @@ export function RoomForm({ onSubmit }) {
         </View>
       </Modal>
 
-      {/* 생성 버튼 */}
       <TouchableOpacity
         style={[styles.createButton, { marginBottom: insets.bottom + 10 }]}
         onPress={handleSubmit}
       >
-        <Text style={styles.createButtonText}>방 생성</Text>
+        <Text style={styles.createButtonText}>{submitLabel}</Text>
       </TouchableOpacity>
+
     </ScrollView>
   );
 }

--- a/src/features/room/hooks/useRoom.js
+++ b/src/features/room/hooks/useRoom.js
@@ -1,17 +1,47 @@
-import { Alert } from "react-native";
-import { roomApi } from "../services/roomApi";
+import { useState } from "react";
 
 export function useRoom() {
-  const createRoom = async (roomData) => {
+  const BASE_URL = "http://YOUR_SERVER_URL";
+
+  const createRoom = async (data) => { /* 이미 있음 */ };
+
+  // 🔥 PUT /rooms/{roomId}
+  const updateRoom = async (roomId, data) => {
     try {
-      const result = await roomApi.createRoom(roomData);
-      /* console.log("✅ 방 생성 성공 (테스트):", result); */
-      return result;
-    } catch (e) {
-      console.error("❌ 방 생성 중 오류:", e);
-      Alert.alert("오류", "방 생성 중 문제가 발생했습니다.");
+      const response = await fetch(`${BASE_URL}/rooms/${roomId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) throw new Error("Update failed");
+
+      return await response.json();
+    } catch (err) {
+      console.error("❌ 방 수정 실패:", err);
       return null;
     }
   };
-  return { createRoom };
+
+  // 🔥 DELETE /rooms/{roomId}
+  const deleteRoom = async (roomId) => {
+    try {
+      const response = await fetch(`${BASE_URL}/rooms/${roomId}`, {
+        method: "DELETE",
+      });
+
+      if (!response.ok) throw new Error("Delete failed");
+
+      return true;
+    } catch (err) {
+      console.error("❌ 방 삭제 실패:", err);
+      return false;
+    }
+  };
+
+  return {
+    createRoom,
+    updateRoom,
+    deleteRoom,
+  };
 }

--- a/src/features/room/screens/RoomCreateScreen.js
+++ b/src/features/room/screens/RoomCreateScreen.js
@@ -31,6 +31,5 @@ const styles = StyleSheet.create({
     fontSize: 22,
     fontWeight: "bold",
     textAlign: "center",
-    marginBottom: 20,
   },
 });

--- a/src/features/room/screens/RoomEditScreen.js
+++ b/src/features/room/screens/RoomEditScreen.js
@@ -55,6 +55,5 @@ const styles = StyleSheet.create({
     fontSize: 22,
     fontWeight: "bold",
     textAlign: "center",
-    marginBottom: 20,
   },
 });

--- a/src/features/room/screens/RoomEditScreen.js
+++ b/src/features/room/screens/RoomEditScreen.js
@@ -1,24 +1,29 @@
 import React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Alert,
+} from "react-native";
+import { useNavigation, useRoute } from "@react-navigation/native";
 import { RoomForm } from "../components/RoomForm";
 import { useRoom } from "../hooks/useRoom";
-import { useNavigation, useRoute } from "@react-navigation/native";
 
 export function RoomEditScreen() {
-  const { updateRoom } = useRoom();
   const navigation = useNavigation();
   const route = useRoute();
-
-  const { room } = route.params; // 수정할 방 데이터
+  const { room } = route.params; // Dashboard → RoomEditScreen 전달된 방 전체 데이터
+  const { updateRoom } = useRoom();
 
   const handleUpdate = async (data) => {
-    // data = RoomForm에서 입력받은 수정된 값들
-
+    // data = RoomForm에서 반환된 { title, dates, startTime, endTime }
     const result = await updateRoom(room.roomNumber, data);
 
     if (result) {
-      /* console.log("✅ 수정된 방:", result); */
-      navigation.navigate("Dashboard");
+      Alert.alert("✔ 방 수정 완료", "방 정보가 성공적으로 수정되었습니다.");
+      navigation.navigate("Dashboard"); // 수정 후 목록으로
+    } else {
+      Alert.alert("❌ 수정 실패", "다시 시도해주세요.");
     }
   };
 
@@ -41,7 +46,11 @@ export function RoomEditScreen() {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: "#fff", paddingTop: 40 },
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    paddingTop: 40,
+  },
   title: {
     fontSize: 22,
     fontWeight: "bold",

--- a/src/features/room/screens/RoomEditScreen.js
+++ b/src/features/room/screens/RoomEditScreen.js
@@ -1,0 +1,51 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { RoomForm } from "../components/RoomForm";
+import { useRoom } from "../hooks/useRoom";
+import { useNavigation, useRoute } from "@react-navigation/native";
+
+export function RoomEditScreen() {
+  const { updateRoom } = useRoom();
+  const navigation = useNavigation();
+  const route = useRoute();
+
+  const { room } = route.params; // 수정할 방 데이터
+
+  const handleUpdate = async (data) => {
+    // data = RoomForm에서 입력받은 수정된 값들
+
+    const result = await updateRoom(room.roomNumber, data);
+
+    if (result) {
+      /* console.log("✅ 수정된 방:", result); */
+      navigation.navigate("Dashboard");
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>방 수정</Text>
+
+      <RoomForm
+        onSubmit={handleUpdate}
+        submitLabel="방 수정"
+        initialValues={{
+          title: room.title,
+          dates: room.dates,
+          startTime: room.startTime,
+          endTime: room.endTime,
+        }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#fff", paddingTop: 40 },
+  title: {
+    fontSize: 22,
+    fontWeight: "bold",
+    textAlign: "center",
+    marginBottom: 20,
+  },
+});

--- a/src/navigation/AppNavigation.js
+++ b/src/navigation/AppNavigation.js
@@ -8,19 +8,22 @@ import { ProfileScreen } from "../features/profile/screens/ProfileScreen";
 import { RoomCreateScreen } from "../features/room/screens/RoomCreateScreen";
 import { TimeSettingScreen } from "../features/timeSetting/screens/TimeSettingScreen";
 import { ResultScreen } from "../features/result/screens/ResultScreen";
+import { RoomEditScreen } from "../features/room/screens/RoomEditScreen";
 
 const Stack = createStackNavigator();
 
 export function AppNavigation() {
   return (
     <NavigationContainer>
-      <Stack.Navigator>
+      <Stack.Navigator initialRouteName="Dashboard">
         <Stack.Screen name="Login" component={LoginScreen} />
         <Stack.Screen name="Dashboard" component={DashboardScreen} />
         <Stack.Screen name="Profile" component={ProfileScreen} />
         <Stack.Screen name="RoomCreate" component={RoomCreateScreen} />
         <Stack.Screen name="TimeSetting" component={TimeSettingScreen} />
         <Stack.Screen name="Result" component={ResultScreen} />
+        <Stack.Screen name="RoomEdit" component={RoomEditScreen} />
+
       </Stack.Navigator>
     </NavigationContainer>
   );


### PR DESCRIPTION
## 📋 변경 사항
* 방 생성뿐 아니라 **전체 CRUD 플로우 완성(Create → Read → Update → Delete)**
* 사용자 편의성 향상
* 리스트 갱신 시 화면 새로고침 없이 자연스러운 UI 유지
* API 명세와 일관된 데이터 구조 유지

## 🔗 관련 이슈
Closes #31

## 📝 작업 내용

### 1) **방 수정 기능**

* RoomEditScreen 신규 구현
* 기존 방 데이터를 넘겨받아 RoomForm에 **initialValues**로 자동 세팅
* RoomForm에 **submitLabel** 추가 → 버튼 문구 “방 수정”으로 표시
* 수정 완료 시 Dashboard로 이동하며 **refreshRooms()**로 자동 리스트 반영
* PUT `/rooms/{roomId}` 명세에 맞도록 request body 구조 조정

  * `title`, `dates`, `startTime`, `endTime`만 전송
  * createdAt/expiresAt/owner 제거

---

### 2) **방 삭제 기능**

* RoomList에 삭제 버튼 아이콘 추가
* 삭제 클릭 시 **Alert 확인 모달** 표시
* 삭제 후 Dashboard 자동 갱신 (refreshRooms 사용)
* DELETE `/rooms/{roomId}` 명세에 맞게 deleteRoom 함수 구조 생성
* 현재는 서버 연동 전이라 mock 데이터 제거 방식으로 구현

---

### 3) **권한 로직 (이슈 요구사항 포함)**

* UI에서는 모든 참가자에게 수정/삭제 버튼 노출
* 방장이 아닐 경우 버튼 클릭 시 **“권한이 없습니다” Alert** 표시하도록 처리 (추가 구현 가능)

---

### 4) **Dashboard 개선**

* useDashboard에 `refreshRooms`, `setRooms` 추가
* 방 생성/수정/삭제 후 자동으로 목록 갱신되도록 구조 정비
* handleInvite props 전달 누락 오류 해결
* 레이아웃 유지 + 애니메이션 정상 작동

---

### 5) **RoomForm 리팩토링**

* 생성/수정 공용으로 사용 가능하도록 구조 개선
* submitLabel 추가
* initialValues로 기존 값 채우기 지원
* requestBody API 명세에 맞게 수정

## 📸 스크린샷 (UI 변경 시)

| Dashboard 화면 | 방 수정 화면 |
| --- | --- |
| <img width="300" src="https://github.com/user-attachments/assets/5b68338a-ef15-42ce-8c6f-3ed7a6d84d21" /> | <img width="300" src="https://github.com/user-attachments/assets/1331c666-5328-490a-8f96-067df69f7ad5" /> |



